### PR TITLE
 Fix bug preventing dynamic overlays from being toggled back on

### DIFF
--- a/LayerSelector.js
+++ b/LayerSelector.js
@@ -12,6 +12,7 @@ define([
     'dojo/_base/lang',
 
     'esri/config',
+    'esri/layers/ArcGISDynamicMapServiceLayer',
     'esri/layers/TileInfo',
     'esri/layers/WebTiledLayer'
 ], function (
@@ -28,6 +29,7 @@ define([
     lang,
 
     esriConfig,
+    ArcGISDynamicMapServiceLayer,
     TileInfo,
     WebTiledLayer
 ) {
@@ -509,7 +511,12 @@ define([
                     }
                 }
 
-                this.map.addLayer(managedLayers[layerItem.name].layer, index);
+                var activeLayer = managedLayers[layerItem.name].layer;
+                this.map.addLayer(activeLayer, index);
+
+                if (activeLayer instanceof ArcGISDynamicMapServiceLayer) {
+                    activeLayer.show();
+                }
 
                 if (level > -1) {
                     this.map._simpleSliderZoomHandler(null, null, null, level);

--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,12 @@
     "bootstrap": "~3.3.5"
   },
   "resolutions": {
-    "dojo": "v1.10.4/esri-3.14.0"
+    "dojo": "v1.10.4/esri-3.14.0",
+    "dojox": "v1.10.4/esri-3.14.0",
+    "dijit": "v1.10.4/esri-3.14.0",
+    "util": "v1.10.4/esri-3.14.0",
+    "dgrid": "0.3.17/esri-3.14.0",
+    "dstore": "v1.1.0"
   },
   "devDependencies": {
     "agrc-jasmine-matchers": "~0.1.0",


### PR DESCRIPTION
There was a bug that prevented ArcGISDynamicMapService layer overlays from being turned on, then off, then back on.  This fixes it.